### PR TITLE
core - filters - each/any value type

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -1,4 +1,4 @@
-# C pyright The Cloud Custodian Authors.
+# Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """
 Resource Filtering Logic
@@ -695,7 +695,7 @@ class ValueFilter(BaseValueFilter):
             v = ComparableVersion(value)
             return s, v
 
-        # no op for 'each'
+        # no op for 'each' or 'any'
         elif self.vtype in ('each', 'any',):
             return sentinel, value
 

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -624,6 +624,7 @@ class ValueFilter(BaseValueFilter):
             else:
                 v, r = self.process_value_type(self.v, r, i)
                 self.vtype = self.vtype.split('_')[0]
+                return value_match(r, v)
         else:
             v = self.v
             return value_match(r, v)

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -1,4 +1,4 @@
-# Copyright The Cloud Custodian Authors.
+# C pyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """
 Resource Filtering Logic
@@ -696,7 +696,7 @@ class ValueFilter(BaseValueFilter):
             return s, v
 
         # no op for 'each'
-        elif self.vtype == 'each':
+        elif self.vtype in ('each', 'any',):
             return sentinel, value
 
         return sentinel, value

--- a/tools/c7n_kube/tests/data/events/create_pod.json
+++ b/tools/c7n_kube/tests/data/events/create_pod.json
@@ -183,6 +183,7 @@
                }
             ],
             "containers":[
+              {"image": "ubuntu"},
                {
                   "name":"web",
                   "image":"nginx",

--- a/tools/c7n_kube/tests/test_policy.py
+++ b/tools/c7n_kube/tests/test_policy.py
@@ -50,10 +50,10 @@ class TestAdmissionControllerMode(KubeTest):
                 'filters': [
                     {
                         'type': 'event',
-                        'key': 'request.userInfo.groups',
-                        'value': 'system:masters',
-                        'op': 'in',
-                        'value_type': 'swap'
+                        'key': 'request.object.spec.containers[].image',
+                        'value': 'nginx',
+                        'op': 'eq',
+                        'value_type': 'any_normalize'
                     }
                 ]
             }, session_factory=factory


### PR DESCRIPTION
introduces new value types: each/any:
- All vtypes also get the new each/any prefix, so you can do stuff like `each_cidr` in a list of cidrs for example or `any_cidr`, use case: in a list of cidrs if any contain a specific IP address 
- This enables stuff like 'regex over list': https://github.com/cloud-custodian/cloud-custodian/issues/2563, another ask for regex over list: https://github.com/cloud-custodian/cloud-custodian/discussions/7658

Sample policy:

```yaml
policies:
  - name: 'no-nginx'
    resource: 'k8s.deployment'
    description: 'Thou shalt not run nginx'
    mode:
      type: k8s-validator
      on-match: warn
      operations:
        - CREATE
    filters:
      - type: value
        key: spec.template.spec.containers[].image
        value: ".*nginx.*"
        op: regex
        value_type: any
```