### PR TITLE
improve usability of c7n-adm command

### DIFF
--- a/docs/source/kubernetes/gettingstarted.rst
+++ b/docs/source/kubernetes/gettingstarted.rst
@@ -61,8 +61,17 @@ There are three main components to a policy:
 * Filters: criteria to produce a specific subset of resources
 * Actions: directives to take on the filtered set of resources
 
-In the example below, we will write a policy that filters for pods with a label "custodian"
-and deletes it:
+First, lets create a pod resource that we want to target with the policy:
+
+.. code-block:: bash
+
+   ❯ kubectl run nginx --image=nginx --labels=name=custodian
+   ❯ kubectl get pod -o wide --show-labels
+    NAME    READY   STATUS    RESTARTS   AGE   IP           NODE     NOMINATED NODE   READINESS GATES   LABELS
+    nginx   1/1     Running   0          24s   10.0.1.224   worker   <none>           <none>            name=custodian
+
+Now in the example below, we will write a policy that filters for pods with a
+label "custodian" and deletes it:
 
 Filename: ``custodian.yml``
 


### PR DESCRIPTION
1. Added information on generating a pod that matches the policy we are having them run
2. Made `endpoint` required since we were expanding a variable and assumed it'd be there
3. Skipped all non-k8s-validator policies in the folder since they would fail