### PR TITLE
mailer - move snsdelivery to late import

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/target.py
+++ b/tools/c7n_mailer/c7n_mailer/target.py
@@ -4,7 +4,6 @@
 import traceback
 
 from .email_delivery import EmailDelivery
-from .sns_delivery import SnsDelivery
 from .utils import decrypt
 
 
@@ -22,6 +21,9 @@ class MessageTargetMixin(object):
         # this sections gets the map of sns_to_addresses to rendered_jinja messages
         # (with resources baked in) and delivers the message to each sns topic
         if sns_delivery:
+            # Import SNS deps (including boto3) only when necessary
+            from .sns_delivery import SnsDelivery
+
             sns_delivery = SnsDelivery(self.config, self.session, self.logger)
             sns_message_packages = sns_delivery.get_sns_message_packages(message)
             sns_delivery.deliver_sns_messages(sns_message_packages, message)


### PR DESCRIPTION
Avoid pulling in boto3 when we're not using SNS.